### PR TITLE
add missing open ul tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,8 +31,9 @@
 
 <hr />
 
+<ul>    
 <li><p><a href="https://education-stan.github.io/tutorial_glmm.html">Multilevel Logistic Models using Rstanarm</a> &nbsp; </p></li>
-	
+
 <li><p><a href="http://mc-stan.org/users/documentation/case-studies/tutorial_rstanarm.html">Multilevel Linear Models using Rstanarm</a> &nbsp; <small><a href="http://mc-stan.org/users/documentation/case-studies.html#multilevel-linear-models-using-rstanarm"><em>(Abstract)</em></a></small></p></li>
 
 <li><p><a href="http://mc-stan.org/users/documentation/case-studies/tutorial_twopl.html">Two-Parameter Logistic Item Response Model</a> &nbsp; <small><a href="http://mc-stan.org/users/documentation/case-studies.html#two-parameter-logistic-item-response-model"><em>(Abstract)</em></a></small></p></li>
@@ -94,7 +95,6 @@
 <li><a href="https://cran.r-project.org/web/packages/RBesT/index.html">RBesT: R Bayesian Evidence Synthesis Tools</a></li>
 <li><a href="https://cran.r-project.org/web/packages/rstantools/index.html">rstantools: Tools for Developing R Packages Interfacing with Stan</a></li>
 <li><a href="https://cran.rstudio.com/web/packages/rstanarm/">rstanarm: Bayesian Applied Regression Modeling via Stan</a>
-
 <ul>
 <li><a href="https://youtu.be/z7zOzL9Rrzs">Webinar &ldquo;Introduction to Bayesian Computation Using the rstanarm Package&rdquo;</a></li>
 </ul></li>


### PR DESCRIPTION
The tutorials section of page `index.html` was missing the open ul tag.   added one.

